### PR TITLE
Add CityHash.Net.Legacy as a NuGet package.

### DIFF
--- a/SnakeBite/SnakeBite.csproj
+++ b/SnakeBite/SnakeBite.csproj
@@ -37,8 +37,9 @@
   </PropertyGroup>
   <PropertyGroup />
   <ItemGroup>
-    <Reference Include="CityHash">
-      <HintPath>..\..\SnakeBite\GzsTool\CityHash.dll</HintPath>
+    <Reference Include="CityHash, Version=0.1.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\CityHash.Net.Legacy.0.1.1\lib\net45\CityHash.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
       <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>

--- a/SnakeBite/packages.config
+++ b/SnakeBite/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="CityHash.Net.Legacy" version="0.1.1" targetFramework="net452" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net452" />
 </packages>

--- a/makebite/makebite.csproj
+++ b/makebite/makebite.csproj
@@ -34,8 +34,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CityHash, Version=0.1.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\SnakeBite\bin\Debug\CityHash.dll</HintPath>
+      <HintPath>..\packages\CityHash.Net.Legacy.0.1.1\lib\net45\CityHash.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
       <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>

--- a/makebite/packages.config
+++ b/makebite/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="CityHash.Net.Legacy" version="0.1.1" targetFramework="net452" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
The existing references would require CityHash.dll to be either in
- a directory that isn't checked in (SnakeBite)
- the output directory (makebite)

This fetches the assembly via NuGet.
